### PR TITLE
Add ruff rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,8 @@ repos:
     rev: v0.12.8
     hooks:
       - id: ruff-check
-        args: [ --fix ]
-      # - id: ruff-format
+        args: [--fix]
+      - id: ruff-format
   - repo: https://github.com/tcort/markdown-link-check
     rev: v3.12.2 # DO NOT UPDATE UNTIL https://github.com/tcort/markdown-link-check/pull/452 IS MERGED
     hooks:

--- a/cosmos_reason1_utils/src/cosmos_reason1_utils/script/__init__.py
+++ b/cosmos_reason1_utils/src/cosmos_reason1_utils/script/__init__.py
@@ -17,6 +17,7 @@ import os
 import resource
 import warnings
 
+
 def init_script(verbose: bool = False):
     """Initialize inference script."""
     # Suppress core dumps

--- a/cosmos_reason1_utils/src/cosmos_reason1_utils/script/_test.py
+++ b/cosmos_reason1_utils/src/cosmos_reason1_utils/script/_test.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cosmos_reason1_utils.script import init_script
 import pytest
+
+from cosmos_reason1_utils.script import init_script
 
 
 @pytest.mark.parametrize("verbose", [True, False])

--- a/cosmos_reason1_utils/src/cosmos_reason1_utils/text.py
+++ b/cosmos_reason1_utils/src/cosmos_reason1_utils/text.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 
 import collections
+import re
 from typing import Any
+
 import pydantic
 from pydantic import Field
-import re
 
 """Text processing utilities."""
 
@@ -111,7 +112,7 @@ def extract_structured_text(text: str) -> tuple[dict[str, list[str]], list[str]]
         if match is None:
             remaining.append(text[start:])
             break
-        remaining.append(text[start:match.start()])
+        remaining.append(text[start : match.start()])
         start = match.end()
         key = match.group(1)
 

--- a/cosmos_reason1_utils/src/cosmos_reason1_utils/vision.py
+++ b/cosmos_reason1_utils/src/cosmos_reason1_utils/vision.py
@@ -161,7 +161,7 @@ def overlay_text(
     images: list[Image.Image],
     *,
     fps: float | None = None,
-    config: OverlayConfig = OverlayConfig(),
+    config: OverlayConfig = OverlayConfig(),  # noqa: B008
 ) -> list[Image.Image]:
     """Overlay text on a list of PIL images with black border.
 
@@ -233,7 +233,9 @@ def overlay_text(
 
 
 def overlay_text_on_tensor(
-    tensor: torch.Tensor, fps: float, config: OverlayConfig = OverlayConfig()
+    tensor: torch.Tensor,
+    fps: float,
+    config: OverlayConfig = OverlayConfig(),  # noqa: B008
 ) -> torch.Tensor:
     """Overlay text on a tensor.
 

--- a/cosmos_reason1_utils/src/cosmos_reason1_utils/vision_test.py
+++ b/cosmos_reason1_utils/src/cosmos_reason1_utils/vision_test.py
@@ -25,6 +25,7 @@ _CHANNELS = 3
 _WIDTH = 4
 _HEIGHT = 5
 
+
 def test_save_tensor(tmp_path: Path):
     save_tensor(torch.ones((_CHANNELS, _WIDTH, _HEIGHT)), f"{tmp_path}/image")
     assert (tmp_path / "image/0.png").exists()
@@ -33,11 +34,14 @@ def test_save_tensor(tmp_path: Path):
         assert (tmp_path / f"video/{i}.png").exists()
 
 
-@pytest.mark.parametrize("shape", [
-    (_CHANNELS, _WIDTH, _HEIGHT),
-    (_FRAMES, _CHANNELS, _WIDTH, _HEIGHT),
-    (_CHANNELS, _FRAMES, _WIDTH, _HEIGHT),
-])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (_CHANNELS, _WIDTH, _HEIGHT),
+        (_FRAMES, _CHANNELS, _WIDTH, _HEIGHT),
+        (_CHANNELS, _FRAMES, _WIDTH, _HEIGHT),
+    ],
+)
 def test_overlay_text_on_tensor(shape):
     raw = torch.ones(shape)
     overlayed = overlay_text_on_tensor(raw, fps=10)

--- a/examples/benchmark/tools/eval/calculate_accuracy.py
+++ b/examples/benchmark/tools/eval/calculate_accuracy.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         "--result_dir",
         type=str,
         required=True,
-        help="Directory containing JSON evaluation files to be processed"
+        help="Directory containing JSON evaluation files to be processed",
     )
     args = parser.parse_args()
 
@@ -67,17 +67,22 @@ if __name__ == "__main__":
 
     # Process each JSON file found in the directory.
     for json_file in json_files:
-        print(f"Processing file: {json_file}")  # Provide feedback on which file is being processed
+        print(
+            f"Processing file: {json_file}"
+        )  # Provide feedback on which file is being processed
 
         # --- File Processing & Error Handling ---
         try:
             # Open and load data from the current JSON file. Using UTF-8 encoding is standard practice.
-            with open(json_file, "r", encoding='utf-8') as f:
+            with open(json_file, encoding="utf-8") as f:
                 data = json.load(f)
 
                 # Validate that the loaded data is a list, as expected for iteration.
                 if not isinstance(data, list):
-                    print(f"Warning: Skipping file '{json_file}'. Expected the top level to be a list of items, but found {type(data).__name__}.", file=sys.stderr)
+                    print(
+                        f"Warning: Skipping file '{json_file}'. Expected the top level to be a list of items, but found {type(data).__name__}.",
+                        file=sys.stderr,
+                    )
                     continue  # Skip this file and move to the next one
 
                 # Iterate through each item (expected to be an evaluation result) in the loaded list.
@@ -94,20 +99,31 @@ if __name__ == "__main__":
 
         # Handle specific errors that might occur during file operations or JSON parsing.
         except FileNotFoundError:
-            print(f"Error: File not found while attempting to process '{json_file}'.", file=sys.stderr)
+            print(
+                f"Error: File not found while attempting to process '{json_file}'.",
+                file=sys.stderr,
+            )
         except json.JSONDecodeError:
-            print(f"Error: Could not decode JSON from file '{json_file}'. Please ensure the file is valid JSON.", file=sys.stderr)
+            print(
+                f"Error: Could not decode JSON from file '{json_file}'. Please ensure the file is valid JSON.",
+                file=sys.stderr,
+            )
         except Exception as e:
             # Catch any other unexpected errors during the processing of a file.
-            print(f"An unexpected error occurred while processing '{json_file}': {e}", file=sys.stderr)
+            print(
+                f"An unexpected error occurred while processing '{json_file}': {e}",
+                file=sys.stderr,
+            )
 
     # --- Results Calculation & Output ---
     # Calculate the mean accuracy. Use a float division. If no samples were processed, accuracy is 0.0.
     accuracy = float(total_correct) / total_samples if total_samples > 0 else 0.0
 
     # Print the final aggregated results collected from all processed files.
-    print("\n--- Aggregated Results ---")  # Add a header for clarity of the final output
+    print(
+        "\n--- Aggregated Results ---"
+    )  # Add a header for clarity of the final output
     print(f"Total samples processed across all files: {total_samples}")
     print(f"Total samples counted as correct: {total_correct}")
     # Print the mean accuracy formatted to 4 decimal places and as a percentage to 2 decimal places.
-    print(f"Mean accuracy: {accuracy:.4f} ({accuracy*100:.2f}%)")
+    print(f"Mean accuracy: {accuracy:.4f} ({accuracy * 100:.2f}%)")

--- a/examples/benchmark/tools/eval/process_raw_data.py
+++ b/examples/benchmark/tools/eval/process_raw_data.py
@@ -38,15 +38,14 @@ import re
 import subprocess
 import tarfile
 import urllib.request
-from typing import Tuple, Optional, List
 
 import cv2
+import ffmpeg
 import numpy as np
 import tensorflow_datasets as tfds
 from datasets import load_dataset
+from huggingface_hub import HfApi, hf_hub_download, login
 from tqdm import tqdm
-import ffmpeg
-from huggingface_hub import login, HfApi, hf_hub_download
 
 """Download and unpack datasets."""
 
@@ -72,7 +71,7 @@ def tqdm_hook(t):
     return update_to
 
 
-def download_agibot_data(data_dir: str, hf_token: Optional[str] = None):
+def download_agibot_data(data_dir: str, hf_token: str | None = None):
     """
     Download all data from the AgiBotWorld-Beta dataset on Hugging Face
     and extract any .tar files found.
@@ -97,7 +96,7 @@ def download_agibot_data(data_dir: str, hf_token: Optional[str] = None):
         print("No Hugging Face token provided. Attempting to use cached credentials...")
 
     # Create target directory if it doesn't exist
-    target_dir = os.path.join(data_dir, 'raw', dataset)
+    target_dir = os.path.join(data_dir, "raw", dataset)
     os.makedirs(target_dir, exist_ok=True)
 
     # Initialize the Hugging Face API
@@ -107,14 +106,11 @@ def download_agibot_data(data_dir: str, hf_token: Optional[str] = None):
         print(f"Accessing repository: {repo_id}")
 
         # List repository contents
-        files = api.list_repo_files(
-            repo_id=repo_id,
-            repo_type=repo_type
-        )
+        files = api.list_repo_files(repo_id=repo_id, repo_type=repo_type)
 
         # Count .tar files for information
-        tar_files = [f for f in files if f.endswith('.tar')]
-        other_files = [f for f in files if not f.endswith('.tar')]
+        tar_files = [f for f in files if f.endswith(".tar")]
+        other_files = [f for f in files if not f.endswith(".tar")]
 
         print(f"\nFound {len(files)} total files in the repository:")
         print(f"- {len(tar_files)} .tar files that will be extracted")
@@ -130,7 +126,7 @@ def download_agibot_data(data_dir: str, hf_token: Optional[str] = None):
         for i, file_path in enumerate(files):
             try:
                 # Extract directory part from file path
-                dir_parts = os.path.dirname(file_path).split('/')
+                dir_parts = os.path.dirname(file_path).split("/")
                 if dir_parts and dir_parts[0]:
                     subdir_path = os.path.join(target_dir, *dir_parts)
                     os.makedirs(subdir_path, exist_ok=True)
@@ -143,22 +139,30 @@ def download_agibot_data(data_dir: str, hf_token: Optional[str] = None):
 
                 # Simple check if file already exists
                 if os.path.exists(local_file_path):
-                    print(f"\n({i+1}/{len(files)}) Skipping {file_path} as it already exists at {local_file_path}")
+                    print(
+                        f"\n({i + 1}/{len(files)}) Skipping {file_path} as it already exists at {local_file_path}"
+                    )
                     downloaded_files.append(local_file_path)
 
                     # Check if we should extract existing tar files that weren't extracted before
-                    if file_path.endswith('.tar') and not os.path.exists(os.path.join(subdir_path, ".extraction_completed")):
-                        print(f"Extracting existing file {file_name} to {subdir_path}...")
-                        with tarfile.open(local_file_path, 'r') as tar:
+                    if file_path.endswith(".tar") and not os.path.exists(
+                        os.path.join(subdir_path, ".extraction_completed")
+                    ):
+                        print(
+                            f"Extracting existing file {file_name} to {subdir_path}..."
+                        )
+                        with tarfile.open(local_file_path, "r") as tar:
                             tar.extractall(path=subdir_path)
                         # Create marker file to avoid re-extraction in future runs
-                        with open(os.path.join(subdir_path, ".extraction_completed"), "w") as f:
+                        with open(
+                            os.path.join(subdir_path, ".extraction_completed"), "w"
+                        ) as f:
                             f.write("Extraction completed")
                         print(f"Extraction of existing {file_name} complete.")
 
                     continue
 
-                print(f"\n({i+1}/{len(files)}) Downloading {file_path}...")
+                print(f"\n({i + 1}/{len(files)}) Downloading {file_path}...")
 
                 # Download file from Hugging Face
                 downloaded_file = hf_hub_download(
@@ -167,27 +171,29 @@ def download_agibot_data(data_dir: str, hf_token: Optional[str] = None):
                     token=hf_token,
                     repo_type=repo_type,
                     local_dir=target_dir,
-                    local_dir_use_symlinks=False
+                    local_dir_use_symlinks=False,
                 )
 
                 downloaded_files.append(downloaded_file)
 
                 # Extract if it's a .tar file
-                if file_path.endswith('.tar'):
+                if file_path.endswith(".tar"):
                     print(f"Extracting {file_name} to {subdir_path}...")
-                    with tarfile.open(downloaded_file, 'r') as tar:
+                    with tarfile.open(downloaded_file, "r") as tar:
                         tar.extractall(path=subdir_path)
                     # Create marker file to avoid re-extraction in future runs
-                    with open(os.path.join(subdir_path, ".extraction_completed"), "w") as f:
+                    with open(
+                        os.path.join(subdir_path, ".extraction_completed"), "w"
+                    ) as f:
                         f.write("Extraction completed")
                     print(f"Extraction of {file_name} complete.")
 
                 print(f"Successfully processed {file_name}")
             except Exception as e:
-                print(f"Error processing {file_path}: {str(e)}")
+                print(f"Error processing {file_path}: {e!s}")
 
         # Summary
-        tar_downloads = sum(1 for f in downloaded_files if f.endswith('.tar'))
+        tar_downloads = sum(1 for f in downloaded_files if f.endswith(".tar"))
         other_downloads = len(downloaded_files) - tar_downloads
 
         print("\nDownload complete!")
@@ -198,13 +204,13 @@ def download_agibot_data(data_dir: str, hf_token: Optional[str] = None):
         return downloaded_files
 
     except Exception as e:
-        print(f"Error accessing repository: {str(e)}")
+        print(f"Error accessing repository: {e!s}")
         print("Please verify the repository exists and your token has access.")
         return []
 
 
-def download_holoassist_data(data_dir: str, dataset: str) -> Tuple[str, str]:
-    raw_dataset_path = os.path.join(data_dir, 'raw', dataset)
+def download_holoassist_data(data_dir: str, dataset: str) -> tuple[str, str]:
+    raw_dataset_path = os.path.join(data_dir, "raw", dataset)
     os.makedirs(raw_dataset_path, exist_ok=True)
 
     # Download metadata
@@ -213,8 +219,10 @@ def download_holoassist_data(data_dir: str, dataset: str) -> Tuple[str, str]:
 
     if not os.path.exists(metadata_path):
         log.info(f"Downloading HoloAssist metadata from {metadata_url}...")
-        with tqdm(unit='B', unit_scale=True, desc="Metadata", ncols=80) as t:
-            urllib.request.urlretrieve(metadata_url, metadata_path, reporthook=tqdm_hook(t))
+        with tqdm(unit="B", unit_scale=True, desc="Metadata", ncols=80) as t:
+            urllib.request.urlretrieve(
+                metadata_url, metadata_path, reporthook=tqdm_hook(t)
+            )
 
     # Download and extract videos
     video_url = "https://hl2data.z5.web.core.windows.net/holoassist-data-release/video_pitch_shifted.tar"
@@ -223,8 +231,10 @@ def download_holoassist_data(data_dir: str, dataset: str) -> Tuple[str, str]:
 
     if not os.path.exists(video_extract_path):
         log.info(f"Downloading HoloAssist video data from {video_url}...")
-        with tqdm(unit='B', unit_scale=True, desc="Video Data", ncols=80) as t:
-            urllib.request.urlretrieve(video_url, video_tar_path, reporthook=tqdm_hook(t))
+        with tqdm(unit="B", unit_scale=True, desc="Video Data", ncols=80) as t:
+            urllib.request.urlretrieve(
+                video_url, video_tar_path, reporthook=tqdm_hook(t)
+            )
 
         log.info(f"Extracting video data to {video_extract_path}...")
         os.makedirs(video_extract_path, exist_ok=True)
@@ -237,15 +247,19 @@ def download_holoassist_data(data_dir: str, dataset: str) -> Tuple[str, str]:
 
 def load_holoassist_data(data_dir: str, dataset: str) -> dict[str, dict]:
     metadata_path, _ = download_holoassist_data(data_dir, dataset)
-    with open(metadata_path, 'r') as f:
+    with open(metadata_path) as f:
         data = json.load(f)
 
     video_action_map = {}
-    base_video_path = os.path.join(data_dir, 'raw', dataset, 'videos')
+    base_video_path = os.path.join(data_dir, "raw", dataset, "videos")
 
     for entry in data:
         video_name = entry["video_name"]
-        fine_actions = [event for event in entry.get("events", []) if event.get("label") == "Fine grained action"]
+        fine_actions = [
+            event
+            for event in entry.get("events", [])
+            if event.get("label") == "Fine grained action"
+        ]
         if not fine_actions:
             continue
 
@@ -255,13 +269,15 @@ def load_holoassist_data(data_dir: str, dataset: str) -> dict[str, dict]:
 
         video_action_map[video_name] = {
             "actions": fine_actions,
-            "video_path": video_file_path
+            "video_path": video_file_path,
         }
 
     return video_action_map
 
 
-def get_holoassist_clip_info(clip_name: str, video_action_map: dict[str, list[dict]]) -> Tuple[Optional[str], Optional[float], Optional[float]]:
+def get_holoassist_clip_info(
+    clip_name: str, video_action_map: dict[str, list[dict]]
+) -> tuple[str | None, float | None, float | None]:
     match = re.search(r"^(.*?)_coarse_(\d+)_fine_(\d+)", clip_name)
     if not match:
         log.info("Pattern not matched.")
@@ -274,10 +290,15 @@ def get_holoassist_clip_info(clip_name: str, video_action_map: dict[str, list[di
         log.info(f"Prefix '{prefix}' not found in video_action_map.")
         return None, None, None
 
-    action = next((d for d in video_action_map[prefix]["actions"] if d["id"] == fine_id), None)
+    action = next(
+        (d for d in video_action_map[prefix]["actions"] if d["id"] == fine_id), None
+    )
     return prefix, action["start"], action["end"] if action else (None, None, None)
 
-def get_agibot_clip_info(clip_name: str, data_dir: str) -> Tuple[str, str, str, int, int]:
+
+def get_agibot_clip_info(
+    clip_name: str, data_dir: str
+) -> tuple[str, str, str, int, int]:
     # Remove "clips/" prefix and ".mp4" suffix if present
     clip_name = clip_name.strip()
     if clip_name.startswith("clips/"):
@@ -294,11 +315,14 @@ def get_agibot_clip_info(clip_name: str, data_dir: str) -> Tuple[str, str, str, 
     end_frame = int(parts[4])
 
     # Construct video path according to the new format
-    video_path = f"{data_dir}/agibot/observations/{task_id}/{episode_id}/videos/{video_name}.mp4"
+    video_path = (
+        f"{data_dir}/agibot/observations/{task_id}/{episode_id}/videos/{video_name}.mp4"
+    )
 
     return video_path, video_name, episode_id, start_frame, end_frame
 
-def get_bridge_clip_info(clip_name: str) -> Tuple[str, str, int, int]:
+
+def get_bridge_clip_info(clip_name: str) -> tuple[str, str, int, int]:
     folder_name, episode_id, _, clipframe, _ = clip_name.split(".")
     end_frame = int(clipframe[-3:])
     video_path = f"/nfs/kun2/users/homer/datasets/bridge_data_all/{folder_name.replace('-', '/')}/out.npy"
@@ -323,25 +347,38 @@ def download_bridge_dataset(data_dir: str, split: str, dataset: str) -> None:
     os.chdir(target_dir)
 
     # Use wget with more precise control to avoid downloading parent directory files
-    subprocess.run([
-        "wget", "-r", "-nH", "--cut-dirs=4", "--no-clobber",
-        "--no-parent", "--level=2",  # Prevent going up directories and limit depth
-        f"--reject=index.html*,bridge_dataset-{reject}*",
-        url
-    ], check=True)
+    subprocess.run(
+        [
+            "wget",
+            "-r",
+            "-nH",
+            "--cut-dirs=4",
+            "--no-clobber",
+            "--no-parent",
+            "--level=2",  # Prevent going up directories and limit depth
+            f"--reject=index.html*,bridge_dataset-{reject}*",
+            url,
+        ],
+        check=True,
+    )
 
     # Report on downloaded files
     log.info(f"Finished downloading Bridge dataset (split: {split}).")
 
 
-
-def save_clip(images: List[np.ndarray], data_dir: str, dataset: str, clip_name: str, task: str = "benchmark") -> None:
+def save_clip(
+    images: list[np.ndarray],
+    data_dir: str,
+    dataset: str,
+    clip_name: str,
+    task: str = "benchmark",
+) -> None:
     clips_dir = os.path.join(data_dir, task, dataset, "clips")
     os.makedirs(clips_dir, exist_ok=True)
     clip_path = os.path.join(clips_dir, clip_name)
 
     height, width = images[0].shape[:2]
-    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out = cv2.VideoWriter(clip_path, fourcc, 30.0, (width, height))
 
     for img in images:
@@ -356,12 +393,15 @@ def get_video_fps(video_path: str) -> float:
     """Get FPS using ffmpeg, fallback to 30.0 if failed."""
     try:
         probe = ffmpeg.probe(video_path)
-        video_stream = next((stream for stream in probe['streams'] if stream['codec_type'] == 'video'), None)
+        video_stream = next(
+            (stream for stream in probe["streams"] if stream["codec_type"] == "video"),
+            None,
+        )
         if video_stream:
-            fps_str = video_stream['r_frame_rate']
+            fps_str = video_stream["r_frame_rate"]
             # Handle fractional frame rates like "30000/1001"
-            if '/' in fps_str:
-                num, den = map(int, fps_str.split('/'))
+            if "/" in fps_str:
+                num, den = map(int, fps_str.split("/"))
                 fps = num / den
             else:
                 fps = float(fps_str)
@@ -371,7 +411,14 @@ def get_video_fps(video_path: str) -> float:
     return 30.0
 
 
-def preprocess_clip(clip_names: List[str], dataset: str, data_dir: Optional[str] = None, split: str = "val", hf_token: Optional[str] = None, task: str = "benchmark") -> None:
+def preprocess_clip(
+    clip_names: list[str],
+    dataset: str,
+    data_dir: str | None = None,
+    split: str = "val",
+    hf_token: str | None = None,
+    task: str = "benchmark",
+) -> None:
     if dataset == "holoassist":
         video_action_map = load_holoassist_data(data_dir, dataset)
     elif dataset == "bridgev2":
@@ -379,42 +426,58 @@ def preprocess_clip(clip_names: List[str], dataset: str, data_dir: Optional[str]
     elif dataset == "agibot":
         download_agibot_data(data_dir, hf_token)
     else:
-        raise ValueError("Invalid dataset specified. Choose 'holoassist', 'bridge', or 'agibot'.")
+        raise ValueError(
+            "Invalid dataset specified. Choose 'holoassist', 'bridge', or 'agibot'."
+        )
 
     video_clip_map = {}
 
     for clip_name in clip_names:
         if dataset == "holoassist":
-            video_name, start, end = get_holoassist_clip_info(clip_name, video_action_map)
+            video_name, start, end = get_holoassist_clip_info(
+                clip_name, video_action_map
+            )
             if video_name:
-                video_clip_map.setdefault(video_name, []).append({
-                    'clip_name': clip_name,
-                    'start_frame': start,
-                    'end_frame': end,
-                    'video_path': video_action_map[video_name]['video_path'],
-                })
+                video_clip_map.setdefault(video_name, []).append(
+                    {
+                        "clip_name": clip_name,
+                        "start_frame": start,
+                        "end_frame": end,
+                        "video_path": video_action_map[video_name]["video_path"],
+                    }
+                )
         elif dataset == "bridgev2":
             video_name, episode_id, start, end = get_bridge_clip_info(clip_name)
-            video_clip_map.setdefault(video_name, []).append({
-                'clip_name': clip_name,
-                'episode_id': episode_id,
-                'start_frame': start,
-                'end_frame': end
-            })
+            video_clip_map.setdefault(video_name, []).append(
+                {
+                    "clip_name": clip_name,
+                    "episode_id": episode_id,
+                    "start_frame": start,
+                    "end_frame": end,
+                }
+            )
         elif dataset == "agibot":
-            video_path, video_name, episode_id, start, end = get_agibot_clip_info(clip_name, f"{data_dir}/raw")
-            video_clip_map.setdefault(video_name, []).append({
-                'clip_name': clip_name,
-                'episode_id': episode_id,
-                'start_frame': start,
-                'end_frame': end,
-                'video_path': video_path
-            })
+            video_path, video_name, episode_id, start, end = get_agibot_clip_info(
+                clip_name, f"{data_dir}/raw"
+            )
+            video_clip_map.setdefault(video_name, []).append(
+                {
+                    "clip_name": clip_name,
+                    "episode_id": episode_id,
+                    "start_frame": start,
+                    "end_frame": end,
+                    "video_path": video_path,
+                }
+            )
         else:
-            raise ValueError("Invalid dataset specified. Choose 'holoassist', 'bridgev2', or 'agibot'.")
+            raise ValueError(
+                "Invalid dataset specified. Choose 'holoassist', 'bridgev2', or 'agibot'."
+            )
 
     if dataset == "bridgev2":
-        ds = tfds.load("bridge_dataset", split=split, data_dir=f"{data_dir}/raw/{dataset}")
+        ds = tfds.load(
+            "bridge_dataset", split=split, data_dir=f"{data_dir}/raw/{dataset}"
+        )
         log.info(f"Number of videos in Bridge V2 {split} split: {len(ds)}")
         n_no_instruction = 0
         try:
@@ -423,13 +486,18 @@ def preprocess_clip(clip_names: List[str], dataset: str, data_dir: Optional[str]
                     n_no_instruction += 1
                     continue
 
-                video_name_tfds = episode["episode_metadata"]["file_path"].numpy().decode("utf-8")
+                video_name_tfds = (
+                    episode["episode_metadata"]["file_path"].numpy().decode("utf-8")
+                )
                 episode_id_tfds = str(episode["episode_metadata"]["episode_id"].numpy())
 
                 for clip_info in video_clip_map.get(video_name_tfds, []):
-                    if episode_id_tfds == clip_info['episode_id']:
-                        images = [step["observation"]["image_0"].numpy() for step in episode["steps"]]
-                        save_clip(images, data_dir, dataset, clip_info['clip_name'])
+                    if episode_id_tfds == clip_info["episode_id"]:
+                        images = [
+                            step["observation"]["image_0"].numpy()
+                            for step in episode["steps"]
+                        ]
+                        save_clip(images, data_dir, dataset, clip_info["clip_name"])
         except Exception:
             log.warning("Clip processing error!")
 
@@ -438,54 +506,64 @@ def preprocess_clip(clip_names: List[str], dataset: str, data_dir: Optional[str]
     elif dataset == "holoassist" or dataset == "agibot":
         log.info(f"Number of videos in {dataset}: {len(video_clip_map)}")
 
-        for video_id, clips in video_clip_map.items():
+        for video_id, clips in video_clip_map.items():  # noqa: B007
             for clip in clips:
-                input_video_path = clip['video_path']
+                input_video_path = clip["video_path"]
 
                 # Skip processing if video file doesn't exist
                 if not os.path.exists(input_video_path):
-                    log.warning(f"Skipping clip {clip['clip_name']} - video file not found")
+                    log.warning(
+                        f"Skipping clip {clip['clip_name']} - video file not found"
+                    )
                     continue
 
                 # Calculate start and end times in seconds
                 if dataset == "agibot":
                     # Get actual FPS using OpenCV
                     fps = get_video_fps(input_video_path)
-                    start_time = clip['start_frame'] / fps
-                    end_time = clip['end_frame'] / fps
+                    start_time = clip["start_frame"] / fps
+                    end_time = clip["end_frame"] / fps
                 elif dataset == "holoassist":
                     # For holoassist, start_frame and end_frame are already in seconds
-                    start_time = clip['start_frame']
-                    end_time = clip['end_frame']
+                    start_time = clip["start_frame"]
+                    end_time = clip["end_frame"]
 
                 # Create output path using clip name
-                output_video = os.path.join(data_dir, task, dataset, "clips", f"{clip['clip_name']}")
+                output_video = os.path.join(
+                    data_dir, task, dataset, "clips", f"{clip['clip_name']}"
+                )
                 os.makedirs(os.path.dirname(output_video), exist_ok=True)
 
                 try:
                     # Force software decoding for AV1 compatibility
-                    ffmpeg.input(input_video_path, ss=start_time, to=end_time,
-                                hwaccel="none").output(
-                        output_video, vcodec="libx264", acodec="aac",
-                        **{"c:v": "libx264", "preset": "fast"}
+                    ffmpeg.input(
+                        input_video_path, ss=start_time, to=end_time, hwaccel="none"
+                    ).output(
+                        output_video,
+                        vcodec="libx264",
+                        acodec="aac",
+                        **{"c:v": "libx264", "preset": "fast"},
                     ).run(quiet=True, overwrite_output=True)
                     log.info(f"Saved clip to: {output_video}")
                 except Exception as e:
                     log.warning(f"Failed to extract clip {clip['clip_name']}: {e}")
+
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--datasets", type=str, nargs="*", choices=ALL_DATASETS)
     parser.add_argument("--data_dir", type=str, default="data")
     parser.add_argument("--token", type=str)
-    parser.add_argument("--task", type=str, choices=["benchmark", "sft", "rl"], required=True)
+    parser.add_argument(
+        "--task", type=str, choices=["benchmark", "sft", "rl"], required=True
+    )
 
     args = parser.parse_args()
 
     hf_dataset_map = {
         "benchmark": "nvidia/Cosmos-Reason1-Benchmark",
         "sft": "nvidia/Cosmos-Reason1-SFT-Dataset",
-        "rl": "nvidia/Cosmos-Reason1-RL-Dataset"
+        "rl": "nvidia/Cosmos-Reason1-RL-Dataset",
     }
 
     split = "val" if args.task == "benchmark" else "train"
@@ -493,7 +571,9 @@ def main():
     hf_token = args.token or os.environ.get("HF_TOKEN")
 
     if not hf_token:
-        log.warning("No Hugging Face token (HF_TOKEN) provided via args or environment.")
+        log.warning(
+            "No Hugging Face token (HF_TOKEN) provided via args or environment."
+        )
 
     datasets = args.datasets or ALL_DATASETS
     for dataset in datasets:
@@ -501,9 +581,18 @@ def main():
 
         clip_names = []
         for dataset_name in ds.keys():
-            clip_names.extend([item.split('clips/')[-1] for item in ds[dataset_name]["video"]])
+            clip_names.extend(
+                [item.split("clips/")[-1] for item in ds[dataset_name]["video"]]
+            )
 
-        preprocess_clip(clip_names=clip_names, dataset=dataset, data_dir=args.data_dir, split=split, hf_token=hf_token, task=args.task)
+        preprocess_clip(
+            clip_names=clip_names,
+            dataset=dataset,
+            data_dir=args.data_dir,
+            split=split,
+            hf_token=hf_token,
+            task=args.task,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/benchmark/tools/eval/utils/dummy_model.py
+++ b/examples/benchmark/tools/eval/utils/dummy_model.py
@@ -25,7 +25,7 @@ class DummyOutput:
 
 @attrs.define(slots=False)
 class DummyRequestOutput:
-    outputs = [DummyOutput()]
+    outputs = [DummyOutput()]  # noqa: RUF012
 
 
 class DummyModel:

--- a/examples/benchmark/tools/eval/utils/model_download.py
+++ b/examples/benchmark/tools/eval/utils/model_download.py
@@ -15,13 +15,12 @@
 
 import logging as log
 import os
-from typing import Dict, List
 
-from huggingface_hub import list_repo_files, hf_hub_download
+from huggingface_hub import hf_hub_download, list_repo_files
 
 # Define a dictionary mapping model names to Hugging Face repository IDs.
 # This helps manage repository mappings centrally.
-MODEL_REPO_MAP: Dict[str, str] = {
+MODEL_REPO_MAP: dict[str, str] = {
     "qwen2.5-vl-7b": "Qwen/Qwen2.5-VL-7B-Instruct",
     "qwen2-vl-2b": "Qwen/Qwen2-VL-2B-Instruct",
     "qwen2.5-vl-32b": "Qwen/Qwen2.5-VL-32B-Instruct",
@@ -29,7 +28,7 @@ MODEL_REPO_MAP: Dict[str, str] = {
 }
 
 # Define a list of standard tokenizer filenames to download.
-TOKENIZER_FILENAMES: List[str] = [
+TOKENIZER_FILENAMES: list[str] = [
     "config.json",
     "tokenizer.json",
     "tokenizer_config.json",
@@ -81,14 +80,16 @@ def check_model_shards_complete(model_dir: str) -> bool:
             try:
                 # Extract the total count from the second part before the extension.
                 total_shards = int(parts[1].split(".")[0])
-                break # Found the total count, no need to check other files.
+                break  # Found the total count, no need to check other files.
             except ValueError:
                 # Ignore files that match the pattern but have non-integer shard counts.
                 continue
 
     # If total_shards could not be determined from any file, the check fails.
     if total_shards <= 0:
-        log.error(f"Could not determine the total number of shards from files in {model_dir}")
+        log.error(
+            f"Could not determine the total number of shards from files in {model_dir}"
+        )
         return False
 
     # Generate the set of all expected shard filenames based on the determined total.
@@ -106,11 +107,12 @@ def check_model_shards_complete(model_dir: str) -> bool:
         log.info(f"All {total_shards} model shards found in {model_dir}")
     else:
         missing_shards = expected_shards - actual_shards
-        log.warning(f"Missing {len(missing_shards)}/{total_shards} model shards in {model_dir}.")
+        log.warning(
+            f"Missing {len(missing_shards)}/{total_shards} model shards in {model_dir}."
+        )
         # Optionally log missing files, be cautious with large numbers.
         if len(missing_shards) < 10:
-             log.warning(f"Missing files: {missing_shards}")
-
+            log.warning(f"Missing files: {missing_shards}")
 
     return is_complete
 
@@ -132,7 +134,9 @@ def download_checkpoint(repo_id: str, checkpoint_output_dir: str) -> None:
     if check_model_shards_complete(checkpoint_output_dir):
         return
 
-    log.info(f"Attempting to download all checkpoint files for {repo_id} to {checkpoint_output_dir}")
+    log.info(
+        f"Attempting to download all checkpoint files for {repo_id} to {checkpoint_output_dir}"
+    )
 
     os.makedirs(checkpoint_output_dir, exist_ok=True)
 
@@ -159,9 +163,9 @@ def download_checkpoint(repo_id: str, checkpoint_output_dir: str) -> None:
         except Exception as e:
             log.error(f"Failed to download file {filename} from {repo_id}: {e}")
 
-    log.info(f"Finished downloading all checkpoint files for {repo_id} to {checkpoint_output_dir}")
-
-
+    log.info(
+        f"Finished downloading all checkpoint files for {repo_id} to {checkpoint_output_dir}"
+    )
 
 
 def download_tokenizer(model: str, checkpoint_output_dir: str) -> None:
@@ -179,7 +183,9 @@ def download_tokenizer(model: str, checkpoint_output_dir: str) -> None:
     Raises:
         ValueError: If the provided model name is not recognized.
     """
-    log.info(f"Attempting to download tokenizer files for {model} to {checkpoint_output_dir}")
+    log.info(
+        f"Attempting to download tokenizer files for {model} to {checkpoint_output_dir}"
+    )
 
     # Look up the Hugging Face repository ID based on the model name.
     repo_id = MODEL_REPO_MAP.get(model)
@@ -200,7 +206,7 @@ def download_tokenizer(model: str, checkpoint_output_dir: str) -> None:
         # Check if the file already exists to avoid unnecessary re-downloads.
         if os.path.exists(file_path):
             log.debug(f"Tokenizer file already exists: {filename}")
-            continue # Skip download if file is present.
+            continue  # Skip download if file is present.
 
         log.info(f"Downloading tokenizer file: {filename}")
         try:
@@ -209,10 +215,12 @@ def download_tokenizer(model: str, checkpoint_output_dir: str) -> None:
                 repo_id=repo_id,
                 filename=filename,
                 local_dir=checkpoint_output_dir,
-                local_dir_use_symlinks=False, # Use False for direct file download
+                local_dir_use_symlinks=False,  # Use False for direct file download
             )
         except Exception as e:
-            log.error(f"Failed to download tokenizer file {filename} from {repo_id}: {e}")
+            log.error(
+                f"Failed to download tokenizer file {filename} from {repo_id}: {e}"
+            )
             # Depending on requirements, you might want to raise the exception
             # or continue attempting to download other files. Continuing here.
 

--- a/examples/benchmark/tools/eval/utils/output.py
+++ b/examples/benchmark/tools/eval/utils/output.py
@@ -21,6 +21,7 @@ import re
 
 import attrs
 
+
 #  ------------- output structure -------------
 @attrs.define
 class OutputStructure:
@@ -28,6 +29,7 @@ class OutputStructure:
     Represents the structure for storing input, model output, and evaluation results
     for a single item. Designed to be easily serialized to JSON.
     """
+
     # Input fields derived from the dataset
     datasource: str
     video_id: str
@@ -35,15 +37,15 @@ class OutputStructure:
 
     # Input fields related to the prompt/task
     prompt: str = ""
-    correct_answer: str = "" # The ground truth correct answer for evaluation
+    correct_answer: str = ""  # The ground truth correct answer for evaluation
 
     # Fields for model output
-    reasoning: str = "" # The reasoning provided by the model
-    answer: str = "" # The final answer extracted from the model's response
-    full_response: str = "" # The complete raw response from the model
+    reasoning: str = ""  # The reasoning provided by the model
+    answer: str = ""  # The final answer extracted from the model's response
+    full_response: str = ""  # The complete raw response from the model
 
     # Evaluation field
-    is_correct: bool = False # Boolean indicating if the extracted answer is correct
+    is_correct: bool = False  # Boolean indicating if the extracted answer is correct
 
     @classmethod
     def from_dict(cls, data: dict) -> "OutputStructure":
@@ -65,7 +67,9 @@ class OutputStructure:
             answer=data.get("answer", ""),
             full_response=data.get("full_response", ""),
             is_correct=data.get("is_correct", False),
-            output_json_fname=data.get("output_json_fname"), # Note: output_json_fname is used internally but not saved in the final JSON
+            output_json_fname=data.get(
+                "output_json_fname"
+            ),  # Note: output_json_fname is used internally but not saved in the final JSON
         )
 
 
@@ -127,7 +131,7 @@ def parse_letter_response(output_text: str) -> tuple[str, str]:
         Returns empty strings if no uppercase letter is found.
     """
     answer = ""
-    reasoning = "" # This parser does not extract reasoning
+    reasoning = ""  # This parser does not extract reasoning
 
     # Look for the first single uppercase letter in the text
     letter_match = SINGLE_LETTER_PATTERN.search(output_text)
@@ -157,7 +161,7 @@ def save_single_file(args: tuple[str, list[OutputStructure]]):
 
     # Ensure the output directory exists
     output_dir = os.path.dirname(output_json_fname)
-    if output_dir: # Only try to create directory if path is not just a filename
+    if output_dir:  # Only try to create directory if path is not just a filename
         os.makedirs(output_dir, exist_ok=True)
 
     try:
@@ -165,10 +169,14 @@ def save_single_file(args: tuple[str, list[OutputStructure]]):
             json.dump(results_dicts, f, indent=4)
         log.info(f"Successfully wrote {len(results)} results to '{output_json_fname}'")
     except Exception as e:
-        log.error(f"An error occurred while writing to JSON file '{output_json_fname}': {e}")
+        log.error(
+            f"An error occurred while writing to JSON file '{output_json_fname}': {e}"
+        )
 
 
-def save_results_parallel(output_results: list[OutputStructure], num_processes: int = 4):
+def save_results_parallel(
+    output_results: list[OutputStructure], num_processes: int = 4
+):
     """
     Saves a list of OutputStructure objects to their respective output files
     using multiprocessing for parallel processing.
@@ -207,8 +215,10 @@ def save_results_parallel(output_results: list[OutputStructure], num_processes: 
         for future in concurrent.futures.as_completed(futures):
             arg = futures[future]
             try:
-                future.result() # Retrieve result (or exception)
+                future.result()  # Retrieve result (or exception)
             except Exception as e:
-                log.error(f"Error occurred during parallel saving for file {arg[0]}: {e}")
+                log.error(
+                    f"Error occurred during parallel saving for file {arg[0]}: {e}"
+                )
 
     log.info("Parallel saving process completed.")

--- a/examples/post_training/tools/dataset/cosmos_grpo.py
+++ b/examples/post_training/tools/dataset/cosmos_grpo.py
@@ -23,7 +23,7 @@ init_script()
 import argparse
 import os
 import warnings
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import cosmos_rl.utils.util as util
 import toml
@@ -185,7 +185,7 @@ class CosmosGRPOValDataset(CosmosGRPODataset):
 
 
 def custom_reward_fn(
-    to_be_evaluated: str, reference: Optional[str] = None, *args, **kwargs
+    to_be_evaluated: str, reference: str | None = None, *args, **kwargs
 ) -> float:
     return sum(
         [
@@ -223,7 +223,7 @@ class DemoDataPacker(DataPacker):
         """
         return self.underlying_data_packer.get_rollout_input(item)
 
-    def rollout_collate_fn(self, items: List[Any]) -> Any:
+    def rollout_collate_fn(self, items: list[Any]) -> Any:
         """
         Collate the rollout inputs into a mini-batch for rollout engine
         """
@@ -239,15 +239,15 @@ class DemoDataPacker(DataPacker):
             item, rollout_output, n_ignore_prefix_tokens
         )
 
-    def policy_compute_max_len(self, processed_samples: List[Any]) -> int:
+    def policy_compute_max_len(self, processed_samples: list[Any]) -> int:
         """
         Compute the maximum sequence length of the mini-batch
         """
         return self.underlying_data_packer.policy_compute_max_len(processed_samples)
 
     def policy_collate_fn(
-        self, processed_samples: List[Any], computed_max_len: int
-    ) -> Dict[str, Any]:
+        self, processed_samples: list[Any], computed_max_len: int
+    ) -> dict[str, Any]:
         """
         Collate the mini-batch into the kwargs required by the policy model
         """
@@ -263,17 +263,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", type=str, required=True)
     args = parser.parse_known_args()[0]
-    with open(args.config, "r") as f:
+    with open(args.config) as f:
         config = toml.load(f)
     config = Config.from_dict(config)
 
-    util.prepare_cosmos_data(
-        dataset=config.train.train_policy.dataset
-    )
+    util.prepare_cosmos_data(dataset=config.train.train_policy.dataset)
     if config.train.enable_validation:
-        util.prepare_cosmos_data(
-            dataset=config.validation.dataset
-    )
+        util.prepare_cosmos_data(dataset=config.validation.dataset)
 
     # It is best practice to pass the dataset and val_dataset as factory functions
     # so that the dataset and val_dataset can be loaded on demand. (Not all workers need them)

--- a/examples/post_training/tools/dataset/cosmos_sft.py
+++ b/examples/post_training/tools/dataset/cosmos_sft.py
@@ -75,7 +75,7 @@ class CosmosSFTDataset(Dataset):
                 f"Dataset directory {video_clips_path} does not exist. Please check the dataset path."
             )
         mm_files_paths = {}
-        for root, dirs, files in os.walk(video_clips_path):
+        for root, dirs, files in os.walk(video_clips_path):  # noqa: B007
             for file in files:
                 if file.endswith((".mp4", ".avi", ".mov")):  # Common video extensions
                     mm_files_paths[file] = os.path.join(root, file)
@@ -116,14 +116,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", type=str, required=True)
     args = parser.parse_known_args()[0]
-    with open(args.config, "r") as f:
+    with open(args.config) as f:
         config = toml.load(f)
     config = Config.from_dict(config)
 
     # Each worker needs to prepare the data independently
-    util.prepare_cosmos_data(
-        dataset=config.train.train_policy.dataset
-    )
+    util.prepare_cosmos_data(dataset=config.train.train_policy.dataset)
 
     def get_dataset(config: CosmosConfig) -> Dataset:
         dataset = load_dataset(

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,13 +18,15 @@ target-version = "py310"
 
 [lint]
 select = [
+    "B", # bugbear
     "E", # pycodestyle errors
     "I", # isort
+    "ISC", # flake8-implicit-str-concat
     "F", # pyflakes
+    "UP", # pyupgrade
+    "RUF", # ruff
 ]
 ignore = [
-    # TODO: Fix
-    "I001", # import order
     "E501", # line too long
 ]
 fixable = ["ALL"]

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -59,7 +59,11 @@ import yaml
 from rich import print
 from rich.pretty import pprint
 
-from cosmos_reason1_utils.text import PromptConfig, create_conversation, extract_structured_text
+from cosmos_reason1_utils.text import (
+    PromptConfig,
+    create_conversation,
+    extract_structured_text,
+)
 from cosmos_reason1_utils.vision import (
     VisionConfig,
     overlay_text_on_tensor,
@@ -144,7 +148,7 @@ def main():
     prompt_kwargs = yaml.safe_load(open(args.prompt, "rb"))
     prompt_config = PromptConfig.model_validate(prompt_kwargs)
     vision_kwargs = yaml.safe_load(open(args.vision_config, "rb"))
-    _vision_config =VisionConfig.model_validate(vision_kwargs)
+    _vision_config = VisionConfig.model_validate(vision_kwargs)
     sampling_kwargs = yaml.safe_load(open(args.sampling_params, "rb"))
     sampling_params = vllm.SamplingParams(**sampling_kwargs)
     if args.verbose:
@@ -152,13 +156,15 @@ def main():
         pprint_dict(sampling_kwargs, "SamplingParams")
 
     # Create conversation
-    system_prompts = [open(f"{ROOT}/prompts/addons/english.txt", "r").read()]
+    system_prompts = [open(f"{ROOT}/prompts/addons/english.txt").read()]
     if prompt_config.system_prompt:
         system_prompts.append(prompt_config.system_prompt)
     if args.reasoning and "<think>" not in prompt_config.system_prompt:
         if extract_structured_text(prompt_config.system_prompt)[0]:
-            raise ValueError("Prompt already contains output format. Cannot add reasoning.")
-        system_prompts.append(open(f"{ROOT}/prompts/addons/reasoning.txt", "r").read())
+            raise ValueError(
+                "Prompt already contains output format. Cannot add reasoning."
+            )
+        system_prompts.append(open(f"{ROOT}/prompts/addons/reasoning.txt").read())
     system_prompt = "\n\n".join(map(str.rstrip, system_prompts))
     if args.question:
         user_prompt = args.question

--- a/scripts/inference_sample.py
+++ b/scripts/inference_sample.py
@@ -38,11 +38,13 @@ Example:
 """
 
 from pathlib import Path
-import transformers
+
 import qwen_vl_utils
+import transformers
 
 ROOT = Path(__file__).parents[1]
 SEPARATOR = "-" * 20
+
 
 def main():
     # Load model
@@ -88,14 +90,18 @@ def main():
     # Run inference
     generated_ids = model.generate(**inputs, max_new_tokens=4096)
     generated_ids_trimmed = [
-        out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
+        out_ids[len(in_ids) :]
+        for in_ids, out_ids in zip(inputs.input_ids, generated_ids, strict=False)
     ]
     output_text = processor.batch_decode(
-        generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
+        generated_ids_trimmed,
+        skip_special_tokens=True,
+        clean_up_tokenization_spaces=False,
     )
     print(SEPARATOR)
     print(output_text[0])
     print(SEPARATOR)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add minimal set of ruff lint and format rules. 

Only added lint rules with low false positive rate. These catch common python foot guns. Most rules have auto-fixes.

## Verification

All changes are automatically added by `ruff check --fix` and `ruff check --add-noqa`. Ruff is very mature, so the likelihood of breaking changes is extremely low. This PR should have no functional changes.

Ran a few example commands to be safe.